### PR TITLE
added a check for the classic anchor tag

### DIFF
--- a/anchorjump/jquery.anchorjump.js
+++ b/anchorjump/jquery.anchorjump.js
@@ -1,4 +1,4 @@
-/*! Anchorjump (c) 2012, Rico Sta. Cruz. MIT License.
+/*! Anchorjump (c) 2014, Rico Sta. Cruz. MIT License.
  *   http://github.com/rstacruz/jquery-stuff/tree/master/anchorjump */
 
 // Makes anchor jumps happen with smooth scrolling.


### PR DESCRIPTION
Added the ability to jump to `<a name="foo"></a>`. By default the plugin goes for `#anchor`s first, and if none exists, it checks for a "classic" anchor.
